### PR TITLE
Typo in conda create command in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ This workshop requires a PDAL installation with python bindings. Using conda is 
 
 Using Conda, create a new virtual environment like:
 
-`conda create -n f4g-pdal-workshop -python=3.6 pdal numpy jupyter -c conda-forge`
+`conda create -n f4g-pdal-workshop python=3.6 pdal numpy jupyter -c conda-forge`
 
 This creates a virtual environment with PDAL and numpy installed, using the `conda-forge` channel. Head to a command line interface, switch to the exercises directory in this repository and type:
 


### PR DESCRIPTION
The extraneous `-` on `-python` results in the error:

`conda create: error: argument -p/--prefix: not allowed with argument -n/--name`

Ref. https://conda.io/docs/user-guide/tasks/manage-python.html